### PR TITLE
Remove delegate method

### DIFF
--- a/UICollectionView-separator/JKSeparatorLayout.h
+++ b/UICollectionView-separator/JKSeparatorLayout.h
@@ -19,9 +19,6 @@ FOUNDATION_EXPORT NSString *const SeparatorViewKind;
 /// Index path above which the separator should be shown, or nil if no separator is present.
 - (NSIndexPath *)indexPathForSeparator;
 
-/// Check for index path validity, since layout math doesn’t know about the model.
-- (BOOL)isValidIndexPathForItem:(NSIndexPath *)indexPath;
-
 @end
 
 

--- a/UICollectionView-separator/JKSeparatorLayout.m
+++ b/UICollectionView-separator/JKSeparatorLayout.m
@@ -109,7 +109,13 @@ NSString *const SeparatorViewKind = @"SeparatorViewKind";
 /// Check for index path validity, since layout math doesn’t know about the model.
 - (BOOL)isValidIndexPathForItem:(NSIndexPath *)indexPath;
 {
-	return indexPath.item < [self.collectionView numberOfItemsInSection:0];
+	NSInteger sections = [self.collectionView.dataSource numberOfSectionsInCollectionView:self.collectionView];
+	if (!(indexPath.section < sections)) {
+		return NO;
+	}
+	
+	NSInteger itemsInSection = [self.collectionView.dataSource collectionView:self.collectionView numberOfItemsInSection:indexPath.section];
+	return indexPath.item < itemsInSection;
 }
 
 - (CGSize)collectionViewContentSize

--- a/UICollectionView-separator/JKSeparatorLayout.m
+++ b/UICollectionView-separator/JKSeparatorLayout.m
@@ -99,11 +99,17 @@ NSString *const SeparatorViewKind = @"SeparatorViewKind";
 {
 	// Our indexPathsForItemsInRect doesn’t know anything about item validity and may return
 	// index paths that are actually not in the collection view. So validate the path.
-	if (![self.separatorLayoutDelegate isValidIndexPathForItem:indexPath]) { return nil; }
+	if (![self isValidIndexPathForItem:indexPath]) { return nil; }
     
     UICollectionViewLayoutAttributes *a = [super layoutAttributesForItemAtIndexPath:indexPath];
     a.frame = [self adjustedFrameForAttributes:a];
     return a;
+}
+
+/// Check for index path validity, since layout math doesn’t know about the model.
+- (BOOL)isValidIndexPathForItem:(NSIndexPath *)indexPath;
+{
+	return indexPath.item < [self.collectionView numberOfItemsInSection:0];
 }
 
 - (CGSize)collectionViewContentSize

--- a/UICollectionView-separator/JKViewController.m
+++ b/UICollectionView-separator/JKViewController.m
@@ -138,11 +138,5 @@ static NSUInteger numberOfItemsWithSeparator = 50;
 	return nil;
 }
 
-- (BOOL)isValidIndexPathForItem:(NSIndexPath *)indexPath
-{
-	return indexPath.item < [self.collectionView numberOfItemsInSection:0];
-}
-
-
 
 @end


### PR DESCRIPTION
The protocol method `isValidIndexPathForItem` can be eliminated, as the layout has access to the collectionView.
